### PR TITLE
feat: npm:install task

### DIFF
--- a/docs/jspm.md
+++ b/docs/jspm.md
@@ -6,6 +6,8 @@
 
 Applies the [JSPM Generator](https://github.com/jspm/generator) to an HTML file to populate its import map for module loading using the JSPM Generator [htmlGenerate API](https://github.com/jspm/generator#generating-html).
 
+Alternatively, when targetting an `.importmap` import map file, will output the direct import map JSON.
+
 ## JSPM Template
 
 ### Template Options
@@ -30,8 +32,9 @@ extensions = ['chomp@0.1:jspm']
 [template-options.npm]
 auto-install = true
 
+# Generate an import map for a browser HTML page
 [[task]]
-name = 'test'
+name = 'build:html'
 target = 'public/app.html'
 dep = 'src/app.html'
 template = 'jspm'
@@ -39,6 +42,15 @@ template = 'jspm'
 env = ['browser', 'production', 'module']
 preload = true
 integrity = true
+
+# Generate an import map for a Deno app
+[[task]]
+name = 'build:deno-importmap'
+target = 'deno.importmap'
+dep = 'deno-app.js'
+template = 'jspm'
+[task.template-options]
+env = ['deno', 'production', 'module']
 ```
 
 ### Ejection

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,6 +1,6 @@
 # npm Extension
 
-**Task Definitions**: _['package.json'](#packagejson-task)_<br/>
+**Task Definitions**: _['package.json'](#packagejson-task), ['npm:install'](#npm-install-task)_<br/>
 **Template Definitions**: _['npm'](#npm-template)_<br/>
 **Batcher Defintions**: _['npm'](#npm-batcher)_
 
@@ -46,6 +46,10 @@ When ejecting the template, the install task is entirely removed.
 ## package.json Task
 
 When using `auto-install: true` and the `package.json` file does not exist, the `package.json` task will run an `npm init` with the defaults set to generate one.
+
+## npm:install Task
+
+For any operation that depends on the global npm install, the `npm:install` task is automatically added when using this extension, which when depended upon will ensure the `package-lock.json` exists and has its mtime greater than the `package.json` mtime, running an `npm install` if not.
 
 ## npm Batcher
 

--- a/npm.js
+++ b/npm.js
@@ -1,3 +1,11 @@
+Chomp.registerTask({
+  name: 'npm:install',
+  display: 'init-only',
+  target: 'package-lock.json',
+  dep: 'package.json',
+  run: 'npm install'
+});
+
 Chomp.registerTemplate('npm', function ({ name, deps, env, display, templateOptions: { packages, dev, packageManager = 'npm', autoInstall, ...invalid } }) {
   if (Object.keys(invalid).length)
     throw new Error(`Invalid npm template option "${Object.keys(invalid)[0]}"`);


### PR DESCRIPTION
Adds a default `npm:install` task with the npm extension.