### PR TITLE
rollup: Node.js Rollup engine, full options support and plugins support

### DIFF
--- a/docs/rollup.md
+++ b/docs/rollup.md
@@ -4,16 +4,26 @@
 **Template Definitions**: _['rollup'](#rollup-template)_<br />
 **Batcher Definitions**: _None_
 
-Performs a chunked RollupJS build on the provided application entry point files.
+Performs a chunked RollupJS build, exposing the full RollupJS configuration per the documentation.
 
 ## Babel Template
 
 ### Template Options
 
-* `auto-install` (_Boolean_, default: `true`): Whether to automatically install `rollup` if not present (using the [npm extension](npm.md)). The global npm extension `auto-install` option will take precedence here if not otherwise set.
-* `entries` (_String[]_): List of application entry points.
-* `outdir` (_String[]_): The build output directory.
-* `source-maps` (_Boolean_, default: `true`): Whether to output source maps for the build.
+Exact same options as the RollupJS configuration documentation with a few exceptions / additions:
+
+* `output` should be an object and not an array.
+* `warn: false` is supported to disable warnings.
+* `#PJSON_VERSION` is supported for version substitution in the `banner` output option.
+* `plugin` is an array of `{ package, ...pluginOptions }` option, where the plugin is imported as `import '<package>'`.
+* `autoInstall`: Set to *false* to disable auto install of plugins packages and RollupJS.
+
+The template can run in two "modes":
+
+1. Do not set `output.file` or `output.dir` or `input`, and then the template will set `input` to `dep` and `output.file` to `target` for a single-file build.
+2. Use `input` and `output` options per RollupJS configuration, and `targets` and `deps` will automatically be inferred from this configuration.
+
+Currently `entryFileNames` support is not included for `target` inferrence, although this feature should be added in future.
 
 ### Example
 
@@ -24,11 +34,20 @@ version = 0.1
 extensions = ['chomp@0.1:rollup']
 
 [[task]]
-name = 'build'
 template = 'rollup'
 [task.template-options]
-outdir = 'dist'
-entries = ['lib/app.js', 'lib/feature.js']
+input = ['src/app.js', 'src/feature.js']
+onwarn = false
+sourcemap = true
+[task.template-options.output]
+dir = 'dist'
+banner = '''/*!
+ * App #PJSON_VERSION
+ */'''
+format = 'esm'
+[[task.template-options.plugin]]
+package = '@rollup/plugin-replace'
+"process.env.NODE_ENV" = 'production'
 ```
 
 Where `dist/app.js` and `dist/feature.js` will be created as inlining all their dependencies while having a shared chunk file as appropriate in the build.

--- a/rollup.js
+++ b/rollup.js
@@ -1,23 +1,73 @@
 Chomp.addExtension('chomp@0.1:npm');
 
-Chomp.registerTemplate('rollup', function ({ name, deps, targets, templateOptions: { outdir = 'dist', entries, sourceMaps = true, autoInstall, plugins = [], ...invalid } }) {
-  if (Object.keys(invalid).length)
-    throw new Error(`Invalid rollup template option "${Object.keys(invalid)[0]}", expected one of "outdir", "entries", "source-maps", "plugins" or "auto-install".`);
-  if (!Array.isArray(entries) || !entries.every(entry => typeof entry === 'string'))
-    throw new Error("'entries' must be an array of string module input paths for the Rollup plugin.");
-  const rollupTargets = entries.map(entry => outdir + '/' + entry.split('/').pop());
+Chomp.registerTemplate('rollup', task => {
+  const { name, targets, deps, env, templateOptions } = task;
+  const { autoInstall, onwarn } = templateOptions;
+  if (templateOptions.plugins) {
+    console.log(`Warning: "plugins" option in RollupJS template is no longer supported and will be deprecated, instead use separate "plugin" entries.\nSee the documentation at https://github.com/guybedford/chomp-extensions/blob/main/docs/rollup.md for more information.`);
+    templateOptions.plugin = templateOptions.plugins.map(plugin => ({ 'package': plugin }));
+  }
+  if (templateOptions.entries) {
+    console.log(`Warning: "entries" and "outdir" options in RollupJS template are no longer supported and will be deprecated, instead use the target dependency pattern for single file builds, or directly populate the input and output options per the RollupJS documentation with the extension automatically setting dependencies and targets.\nSee the documentation at https://github.com/guybedford/chomp-extensions/blob/main/docs/rollup.md for more information.`);
+    templateOptions.input = templateOptions.entries;
+    templateOptions.output = templateOptions.output || {};
+    templateOptions.output.dir = templateOptions.outdir || 'dist';
+    delete templateOptions.outdir;
+    delete templateOptions.entries;
+  }
+  const output = templateOptions.output || {};
+  const { banner } = output;
+  delete templateOptions.output;
+  const pjsonVersion = typeof banner === 'string' && banner.includes('#PJSON_VERSION');
+  delete templateOptions.onwarn;
+  const plugins = (templateOptions.plugin || []).map((plugin, idx) => {
+    const { package } = plugin;
+    if (typeof package !== 'string')
+      throw new Error(`No "package" import name provided for RollupJS plugin ${idx + 1}`);
+    return package;
+  });
+  const pluginOpts = (templateOptions.plugin || []).map((plugin, idx) => {
+    delete plugin.package;
+    return `(plugin${idx + 1}.default || plugin${idx + 1})(${JSON.stringify(plugin, null, 2).replace(/\n/g, '\n    ')})`;
+  }).join(',\n  ');
+  delete templateOptions.plugin;
+  const rollupDeps = typeof templateOptions.input === 'string' ? [templateOptions.input] : Array.isArray(templateOptions.input) ? templateOptions.input : Object.values(templateOptions.input || {});
+  const inputNames = (typeof templateOptions.input === 'string' ? [templateOptions.input] : Array.isArray(templateOptions.input) ? templateOptions.input : Object.keys(templateOptions.input || {})).map(name => name.split('/').pop());
+
+  if (output.entryFileNames)
+    console.log('Warning: Chomp RollupJS extension does not yet support target inferral from entryFileNames. It should though. Lets make it happen.');
+
+  const rollupTargets = output.file ? [output.file] : output.dir && !output.entryFileNames ? inputNames.map(name => `${output.dir}${output.dir.endsWith('/') ? '' : '/'}${name}`) : null;
+  
+  const rollupInput = templateOptions.input ? JSON.stringify(templateOptions.input, null, 2).replace(/\n/g, '\n    ') : 'process.env.DEP';
+  delete templateOptions.input;
+  
+  const inputOpts = JSON.stringify(templateOptions, null, 2).replace(/\n/g, '\n  ');
+  const outputOpts = JSON.stringify(output, null, 2).replace(/\n/g, '\n  ');
+
   return [{
-    name: name,
-    deps: [...deps, ...ENV.CHOMP_EJECT ? ['npm:install'] : ['node_modules/rollup', ...plugins.map(p => `node_modules/${p}`)]],
-    targets: [...new Set([...targets, ...rollupTargets])],
-    run: `rollup ${
-      plugins.length > 0
-        ? `${plugins.reduce((acc, plugin) => {
-            acc = acc + `--plugin ${plugin} `;
-            return acc;
-          }, "")}`
-        : ""
-    } ${entries.join(' ')} -d ${outdir}${sourceMaps ? ' -m' : ''}`
+    name,
+    targets: rollupTargets ? [...new Set([...targets, ...rollupTargets])] : targets,
+    deps: [...new Set([...deps, ...rollupDeps]), ...ENV.CHOMP_EJECT ? ['npm:install'] : ['node_modules/rollup', ...plugins.map(p => `node_modules/${p}`)]],
+    env,
+    engine: 'node',
+    run: `  import { rollup } from 'rollup';
+  ${plugins.map((plugin, idx) => `import * as plugin${idx + 1} from '${plugin}';`).join('\n  ')}${pjsonVersion ? `
+  import { readFileSync } from 'fs';
+
+  const { version } = JSON.parse(readFileSync('package.json', 'utf8'));` : ''}
+
+  const bundle = await rollup({
+    input: ${rollupInput},${onwarn === false ? `
+    onwarn () {},` : ''}${pluginOpts ? `
+    plugins: [${pluginOpts}],` : ''}${inputOpts.length > 2 ? `
+    ${inputOpts.slice(6, -4)}` : ''}
+  });
+  await bundle.write({${rollupTargets ? '' : `
+    file: process.env.TARGET,`}${outputOpts.length > 2 ? `
+    ${outputOpts.slice(6, -4).replace('"banner": ' + JSON.stringify(banner), '"banner": `' + (banner || '').replace(/(\`|\${)/, '\\$1').replace('#PJSON_VERSION', '${version}') + '`')}` : ''}
+  });
+`
   }, ...ENV.CHOMP_EJECT ? [] : [{
     template: 'npm',
     templateOptions: {

--- a/rollup.js
+++ b/rollup.js
@@ -12,6 +12,7 @@ Chomp.registerTemplate('rollup', task => {
     templateOptions.input = templateOptions.entries;
     templateOptions.output = templateOptions.output || {};
     templateOptions.output.dir = templateOptions.outdir || 'dist';
+    templateOptions.output.sourcemap = true;
     delete templateOptions.outdir;
     delete templateOptions.entries;
   }


### PR DESCRIPTION
This extends the RollupJS extension to use the Node.js engine and fully support all RollupJS options.

In addition custom plugins and plugin options are also supported.