### PR TITLE
ncc: support esm option

### DIFF
--- a/docs/ncc.md
+++ b/docs/ncc.md
@@ -13,6 +13,7 @@ Uses [ncc](https://github.com/vercel/ncc) to compile a Node.js application into 
 * `assets`: Set to *false* to disable asset builds.
 * `autoInstall`: Set to *false* to disable auto install of plugins packages and RollupJS.
 * `sourceMap`: Set to *true* to enable source maps for the build.
+* `esm`: Set to *true* to output an ES module, or *false* to output CJS. Defaults to format of the input file.
 
 ### Example
 

--- a/ncc.js
+++ b/ncc.js
@@ -1,6 +1,6 @@
 Chomp.addExtension('chomp@0.1:npm');
 
-Chomp.registerTemplate('ncc', ({ name, targets, deps, env, templateOptions: { assets = true, sourceMap, autoInstall, ...invalid} }) => {
+Chomp.registerTemplate('ncc', ({ name, targets, deps, env, templateOptions: { assets = true, sourceMap, autoInstall, esm, ...invalid} }) => {
   if (Object.keys(invalid).length > 0)
     throw new Error(`Invalid key ${Object.keys(invalid)[0]} for ncc template`);
 
@@ -16,7 +16,8 @@ Chomp.registerTemplate('ncc', ({ name, targets, deps, env, templateOptions: { as
   import mkdirp from 'mkdirp';` : ''}
 
   const { code, map, assets } = await ncc(path.resolve(process.env.DEP), {
-    filename: process.env.DEP,
+    filename: process.env.DEP,${typeof esm === 'boolean' ? `
+    esm: ${String(esm)},` : ''}
     sourceMap: ${sourceMap ? `true,
     sourceMapRegister: false` : 'false'},
     quiet: true


### PR DESCRIPTION
This adds support for the ncc `esm` option to select CJS or ESM output.